### PR TITLE
finish implementing random maze

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import Grid from '@mui/material/Grid';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 
+import {draw_maze} from '../wasm/pkg';
+
 type GridParams = {
   cellSize: number; // 1マスの幅（px）
   cols: number; // 横方向のマス数
@@ -56,8 +58,8 @@ function App() {
   const drawGrid = ({ cellSize, cols, rows }: GridParams) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
+    // const ctx = canvas.getContext('2d');
+    // if (!ctx) return;
 
     // キャンバスサイズをグリッドに合わせる
     const width = cellSize * cols;
@@ -65,30 +67,27 @@ function App() {
     canvas.width = width;
     canvas.height = height;
 
-    // クリア
-    ctx.clearRect(0, 0, width, height);
+    console.log(`cellSize = ${cellSize}`);
 
-    // スタイル
-    ctx.strokeStyle = '#9aa0a6';
-    ctx.lineWidth = 1;
+    draw_maze(0, 0, rows, cols, cellSize);
 
-    // 縦線
-    for (let x = 0; x <= cols; x++) {
-      const px = Math.floor(x * cellSize) + 0.5; // crisp line
-      ctx.beginPath();
-      ctx.moveTo(px, 0);
-      ctx.lineTo(px, height);
-      ctx.stroke();
-    }
+    // // 縦線
+    // for (let x = 0; x <= cols; x++) {
+    //   const px = Math.floor(x * cellSize) + 0.5; // crisp line
+    //   ctx.beginPath();
+    //   ctx.moveTo(px, 0);
+    //   ctx.lineTo(px, height);
+    //   ctx.stroke();
+    // }
 
-    // 横線
-    for (let y = 0; y <= rows; y++) {
-      const py = Math.floor(y * cellSize) + 0.5; // crisp line
-      ctx.beginPath();
-      ctx.moveTo(0, py);
-      ctx.lineTo(width, py);
-      ctx.stroke();
-    }
+    // // 横線
+    // for (let y = 0; y <= rows; y++) {
+    //   const py = Math.floor(y * cellSize) + 0.5; // crisp line
+    //   ctx.beginPath();
+    //   ctx.moveTo(0, py);
+    //   ctx.lineTo(width, py);
+    //   ctx.stroke();
+    // }
   };
 
   // 自動プレビュー（デバウンス）

--- a/frontend/wasm/Cargo.lock
+++ b/frontend/wasm/Cargo.lock
@@ -27,10 +27,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "getrandom"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if 1.0.3",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if 1.0.3",
+ "libc",
+ "r-efi",
+ "wasi 0.14.4+wasi-0.2.4",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -61,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +110,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -102,11 +171,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.4+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "getrandom 0.2.16",
  "js-sys",
+ "rand",
  "wasm-bindgen",
  "web-sys",
  "wee_alloc",
@@ -114,21 +200,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if 1.0.3",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -140,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -150,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -163,18 +250,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -213,3 +300,29 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -10,8 +10,10 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.99"
 js-sys = "0.3.77"
+rand = { version = "0.9.0", default-features = false, features = ["small_rng", "std"] }
 wasm-bindgen = "0.2"
 wee_alloc = "0.4.5"
+getrandom = { version = "0.2.15", features = ["js"] }
 
 
 [dependencies.web-sys]

--- a/frontend/wasm/src/algo/kruskal.rs
+++ b/frontend/wasm/src/algo/kruskal.rs
@@ -1,3 +1,6 @@
+use rand::prelude::*;
+use rand::SeedableRng;
+
 use crate::algo::unionfind::UnionFind;
 
 // 縦heightマス・横widthマスのグリッドグラフについて、最小全域木を作成したときに使用しなかった辺を返す
@@ -8,7 +11,22 @@ pub fn extract_unused_maze_edges_by_kruskal(width: usize, height: usize) -> Vec<
             add_adjacent_edge(&mut edges, i, j, width, height);
         }
     }
+
+    let mut random_bytes = [0u8; 8];
+    getrandom::getrandom(&mut random_bytes).unwrap();
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(u64::from_ne_bytes(random_bytes));
+    edges.shuffle(&mut rng);
     kruskal(width * height, edges)
+}
+
+pub fn index_2d_to_1d(row: usize, col: usize, width: usize) -> usize{
+    row * width + col
+}
+
+// row, columnという並びで返す。
+pub fn index_1d_to_2d(idx: usize, width: usize) -> (usize, usize) {
+    let row = idx / width;
+    (row, idx - row * width)
 }
 
 // グリッドグラフにおいて、隣接マスへの辺が存在したらedgesに追加する

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -4,10 +4,15 @@ mod algo;
 
 use wasm_bindgen::prelude::*;
 
+use crate::maze::{draw_shape::set_wall_edges, shape::Point};
+
 
 #[wasm_bindgen]
 extern "C" {
     pub fn alert(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
 }
 
 #[wasm_bindgen]
@@ -16,7 +21,21 @@ pub fn greet(name: &str) {
 }
 
 #[wasm_bindgen]
-pub fn draw_maze() {
-    let context = dom::fetch_2d_context("canvas");
-    // let _ = maze::draw_shape::run(&context);
+pub fn draw_maze(from_x: f64, from_y: f64, row: usize, col: usize, space: f64) {
+    let ctx = dom::fetch_2d_context("canvas");
+
+    let from = Point::new(from_x, from_y);
+    let width = space * col as f64;
+    let height= space * row as f64;
+
+    ctx.clear_rect(from.x, from.y, width, height);
+
+    ctx.begin_path();
+
+    // 外枠を描画
+    ctx.rect(from.x, from.y, width, height);
+
+    set_wall_edges(&ctx, row, col, space);
+
+    ctx.stroke();
 }

--- a/frontend/wasm/src/maze/draw_shape.rs
+++ b/frontend/wasm/src/maze/draw_shape.rs
@@ -1,14 +1,30 @@
-use wasm_bindgen::prelude::*;
 use web_sys::{CanvasRenderingContext2d};
 
+use crate::algo::kruskal;
 use crate::maze::shape::Point;
 
-pub fn line(ctx: &CanvasRenderingContext2d, from: Point, to: Point) -> Result<(), JsValue> {
-
-    ctx.begin_path();
+pub fn set_grid_line(ctx: &CanvasRenderingContext2d, from: (usize, usize), to: (usize, usize), space: f64)  {
+    let from = Point::new(from.0 as f64 * space, from.1 as f64 * space);
+    let to = Point::new(to.0 as f64 * space, to.1 as f64 * space);
     ctx.move_to(from.x, from.y);
     ctx.line_to(to.x, to.y);
-    ctx.stroke();
+}
 
-    Ok(())
+pub fn set_wall_edges(ctx: &CanvasRenderingContext2d, width: usize, height: usize, space: f64) {
+    let unused_vertex = kruskal::extract_unused_maze_edges_by_kruskal(width, height);
+
+    for (node_left, node_right) in unused_vertex {
+        let from = kruskal::index_1d_to_2d(node_left, width);
+        let to = kruskal::index_1d_to_2d(node_right, width);
+        set_boundary(&ctx, from, to, space);
+    }
+}
+
+pub fn set_boundary(ctx: &CanvasRenderingContext2d, from: (usize, usize), to: (usize, usize), space: f64) {
+    if from.0 == to.0 {
+        set_grid_line(ctx, (from.0, to.1), (to.0 + 1, to.1), space);
+    }
+    if from.1 == to.1 {
+        set_grid_line(ctx, (to.0, from.1), (to.0, to.1 + 1), space);
+    }
 }

--- a/frontend/wasm/src/maze/shape.rs
+++ b/frontend/wasm/src/maze/shape.rs
@@ -1,3 +1,5 @@
+use web_sys::CanvasRenderingContext2d;
+
 pub struct Point {
     pub x: f64,
     pub y: f64,
@@ -23,5 +25,12 @@ impl Line {
             from: from,
             to: to,
         }
+    }
+
+    pub fn draw(&self, ctx: &CanvasRenderingContext2d) {
+        ctx.begin_path();
+        ctx.move_to(self.from.x, self.from.y);
+        ctx.line_to(self.to.x, self.to.y);
+        ctx.stroke();
     }
 }


### PR DESCRIPTION
- **canvasnに迷路を表示するように変更**
- **迷路を書くwasmのエントリーポイントを作成**
- **kruskal法の走査する辺をランダムにシャッフル**
- **feat: add function of drawing shapes**
- **chore: update dependencies**

- これで一旦最低限の機能は完了
