### PR TITLE
fix: prevent caret drift in MarkdownEditor when lines wrap

### DIFF
--- a/frontend/src/presentation/widgets/MarkdownEditor/parts/EditorOverlay/EditorOverlay.tsx
+++ b/frontend/src/presentation/widgets/MarkdownEditor/parts/EditorOverlay/EditorOverlay.tsx
@@ -90,6 +90,7 @@ const EditorOverlay = ({ preRef, textareaRef, markdown, onChange, onScroll, onIn
                     top: 0,
                     left: 0,
                     right: 0,
+                    overflow: 'hidden',
                     visibility: 'hidden',
                     pointerEvents: 'none',
                 }}

--- a/frontend/src/presentation/widgets/MarkdownEditor/parts/constants.ts
+++ b/frontend/src/presentation/widgets/MarkdownEditor/parts/constants.ts
@@ -17,4 +17,11 @@ export const sharedEditorStyle: CSSProperties = {
     whiteSpace: 'pre-wrap',
     overflowWrap: 'break-word',
     boxSizing: 'border-box',
+    // Reserve the scrollbar's width on all three overlapping layers (measure
+    // div, pre, textarea) regardless of whether a scrollbar is actually shown.
+    // Without this, the textarea (overflow: auto) narrows once it grows a real
+    // scrollbar while the pre/measure layers (overflow: hidden/visible) don't,
+    // so long lines wrap at a different column and the caret drifts from the
+    // highlighted text underneath it.
+    scrollbarGutter: 'stable',
 };


### PR DESCRIPTION
The textarea (overflow: auto) loses width to its scrollbar once content overflows, while the overlapping pre/measure layers (overflow: hidden) don't, so long lines wrapped at different columns and the caret drifted from the highlighted text and line-number gutter beneath it.