### PR TITLE
迷路作成ページで生成した迷路をwasmで遊べるようにする

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import MazeCreatorPage from "./maze-creator/container/MazeCreatorPage";
+import MazePlayContainer from "./maze-creator/container/page/play/Container";
 import HomePageContainer from "./home/container/page/Container";
 import { BlogTopContainer } from "./blog/container/page/blogs/Container";
 import BlogContainer from "./blog/container/page/blog_id/Container";
@@ -21,6 +22,7 @@ function App() {
           <Route path=":blogId" element={<BlogContainer />} />
         </Route>
         <Route path="/maze" element={<MazeCreatorPage />} />
+        <Route path="/maze/play" element={<MazePlayContainer />} />
         <Route path="/trajectry" element={<TrajectryPageContainer />} />
 
         <Route element={<RequireAuth />}>

--- a/frontend/src/maze-creator/container/MazeCreatorPage.tsx
+++ b/frontend/src/maze-creator/container/MazeCreatorPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -20,8 +21,10 @@ import {
 import Grid from "@mui/material/Grid";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
+import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
 
-import { draw_maze, MazeType } from "../wasm/pkg/wasm.js";
+import { create_random_maze, draw_maze, MazeType } from "../wasm/pkg/wasm.js";
+import type { MazePlayLocationState } from "../presentation/page/play/MazePlayPage";
 
 type GridParams = {
   cellSize: number;
@@ -34,11 +37,14 @@ type Mode = "random" | "single";
 
 function MazeCreatorPage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const navigate = useNavigate();
 
   const [params, setParams] = useState<GridParams>(DEFAULT_PARAMS);
   const [autoPreview, setAutoPreview] = useState<boolean>(true);
   const [mode, setMode] = useState<Mode>("random");
   const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
+  const [playableMaze, setPlayableMaze] =
+    useState<MazePlayLocationState | null>(null);
 
   const { widthPx, heightPx } = useMemo(
     () => ({
@@ -91,8 +97,10 @@ function MazeCreatorPage() {
     canvas.height = height;
     if (m === "single") {
       draw_maze(0, 0, rows, cols, cellSize, MazeType.SingleStroke);
+      setPlayableMaze(null);
     } else {
-      draw_maze(0, 0, rows, cols, cellSize, MazeType.Random);
+      const walls = create_random_maze("canvas", rows, cols, cellSize);
+      setPlayableMaze({ walls: Array.from(walls), rows, cols, cellSize });
     }
   };
 
@@ -114,6 +122,11 @@ function MazeCreatorPage() {
     if (autoPreview) {
       ensureCanvasAndDraw(DEFAULT_PARAMS, "random");
     }
+  };
+
+  const onPlay = () => {
+    if (!playableMaze) return;
+    navigate("/maze/play", { state: playableMaze });
   };
 
   const theme = useMemo(
@@ -300,9 +313,27 @@ function MazeCreatorPage() {
 
           <Paper elevation={2} sx={{ p: 3 }}>
             <Stack spacing={1}>
-              <Typography variant="subtitle1">プレビュー</Typography>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Typography variant="subtitle1">プレビュー</Typography>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  size="small"
+                  startIcon={<SportsEsportsIcon />}
+                  disabled={!playableMaze}
+                  onClick={onPlay}
+                >
+                  この迷路で遊ぶ
+                </Button>
+              </Stack>
               <Typography variant="caption" color="text.secondary">
                 {widthPx} x {heightPx} px
+                {mode === "single" &&
+                  "（一筆書きモードはプレイに対応していません）"}
               </Typography>
               <Box
                 sx={{

--- a/frontend/src/maze-creator/container/page/play/Container.tsx
+++ b/frontend/src/maze-creator/container/page/play/Container.tsx
@@ -1,0 +1,9 @@
+import MazePlayPage from "../../../presentation/page/play/MazePlayPage";
+import { useGenerateProps } from "./useGenerateProps";
+
+export const MazePlayContainer = () => {
+  const generatedProps = useGenerateProps();
+  return <MazePlayPage {...generatedProps} />;
+};
+
+export default MazePlayContainer;

--- a/frontend/src/maze-creator/container/page/play/useGenerateProps.tsx
+++ b/frontend/src/maze-creator/container/page/play/useGenerateProps.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import {
+  MAZE_PLAY_CANVAS_ID,
+  type MazePlayLocationState,
+  type MazePlayPageProps,
+  type MoveDirection,
+} from "../../../presentation/page/play/MazePlayPage";
+import { Direction, MazeGame } from "../../../wasm/pkg/wasm.js";
+
+const DIRECTION_MAP: Record<MoveDirection, Direction> = {
+  up: Direction.Up,
+  right: Direction.Right,
+  down: Direction.Down,
+  left: Direction.Left,
+};
+
+const KEY_TO_DIRECTION: Record<string, MoveDirection> = {
+  ArrowUp: "up",
+  ArrowRight: "right",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+};
+
+export const useGenerateProps = (): MazePlayPageProps => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gameRef = useRef<MazeGame | null>(null);
+  const [isCleared, setIsCleared] = useState(false);
+
+  const mazeState = location.state as MazePlayLocationState | null;
+  const hasMaze = Boolean(
+    mazeState &&
+      mazeState.rows > 0 &&
+      mazeState.cols > 0 &&
+      mazeState.walls.length === mazeState.rows * mazeState.cols,
+  );
+
+  const startGame = () => {
+    if (!mazeState || !canvasRef.current) return;
+    const { walls, rows, cols, cellSize } = mazeState;
+
+    canvasRef.current.width = cols * cellSize;
+    canvasRef.current.height = rows * cellSize;
+
+    gameRef.current?.free();
+    gameRef.current = new MazeGame(
+      MAZE_PLAY_CANVAS_ID,
+      Uint8Array.from(walls),
+      rows,
+      cols,
+      cellSize,
+    );
+    setIsCleared(false);
+  };
+
+  useEffect(() => {
+    if (!hasMaze) return;
+    startGame();
+    return () => {
+      gameRef.current?.free();
+      gameRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMaze]);
+
+  const onMove = (direction: MoveDirection) => {
+    const game = gameRef.current;
+    if (!game) return;
+    game.try_move(DIRECTION_MAP[direction]);
+    setIsCleared(game.is_cleared());
+  };
+
+  useEffect(() => {
+    if (!hasMaze) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      const direction = KEY_TO_DIRECTION[event.key];
+      if (!direction) return;
+      event.preventDefault();
+      onMove(direction);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [hasMaze]);
+
+  return {
+    hasMaze,
+    isCleared,
+    canvasRef,
+    onMove,
+    onPlayAgain: startGame,
+    onBackToCreator: () => navigate("/maze"),
+  };
+};
+
+export default useGenerateProps;

--- a/frontend/src/maze-creator/presentation/page/play/MazePlayPage.stories.tsx
+++ b/frontend/src/maze-creator/presentation/page/play/MazePlayPage.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import MazePlayPage from "./MazePlayPage";
+
+const meta = {
+  title: "MazePlayPage",
+  component: MazePlayPage,
+} satisfies Meta<typeof MazePlayPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playing: Story = {
+  args: {
+    hasMaze: true,
+    isCleared: false,
+    canvasRef: { current: null },
+    onMove: () => {},
+    onPlayAgain: () => {},
+    onBackToCreator: () => {},
+  },
+};
+
+export const Cleared: Story = {
+  args: {
+    hasMaze: true,
+    isCleared: true,
+    canvasRef: { current: null },
+    onMove: () => {},
+    onPlayAgain: () => {},
+    onBackToCreator: () => {},
+  },
+};
+
+export const NoMaze: Story = {
+  args: {
+    hasMaze: false,
+    isCleared: false,
+    canvasRef: { current: null },
+    onMove: () => {},
+    onPlayAgain: () => {},
+    onBackToCreator: () => {},
+  },
+};

--- a/frontend/src/maze-creator/presentation/page/play/MazePlayPage.tsx
+++ b/frontend/src/maze-creator/presentation/page/play/MazePlayPage.tsx
@@ -1,0 +1,155 @@
+import type { RefObject } from "react";
+import {
+  Box,
+  Button,
+  Container,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+
+export const MAZE_PLAY_CANVAS_ID = "maze-play-canvas";
+
+export type MoveDirection = "up" | "right" | "down" | "left";
+
+export type MazePlayLocationState = {
+  walls: number[];
+  rows: number;
+  cols: number;
+  cellSize: number;
+};
+
+export type MazePlayPageProps = {
+  hasMaze: boolean;
+  isCleared: boolean;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  onMove: (direction: MoveDirection) => void;
+  onPlayAgain: () => void;
+  onBackToCreator: () => void;
+};
+
+export const MazePlayPage = (props: MazePlayPageProps) => {
+  const { hasMaze, isCleared, canvasRef, onMove, onPlayAgain, onBackToCreator } =
+    props;
+
+  if (!hasMaze) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 4 }}>
+        <Paper elevation={2} sx={{ p: 3 }}>
+          <Stack spacing={2} alignItems="flex-start">
+            <Typography variant="h6">遊べる迷路がありません</Typography>
+            <Typography variant="body2" color="text.secondary">
+              迷路作成ページでランダム迷路を作ってから「この迷路で遊ぶ」を押してください。
+            </Typography>
+            <Button variant="contained" onClick={onBackToCreator}>
+              迷路作成ページへ
+            </Button>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Paper elevation={2} sx={{ p: 3 }}>
+          <Stack spacing={2} alignItems="center">
+            <Typography variant="h5">迷路で遊ぶ</Typography>
+
+            {isCleared && (
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={{ color: "success.main" }}
+              >
+                <EmojiEventsIcon />
+                <Typography variant="subtitle1">クリア！</Typography>
+              </Stack>
+            )}
+
+            <Box
+              sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                width: "fit-content",
+              }}
+            >
+              <canvas
+                id={MAZE_PLAY_CANVAS_ID}
+                ref={canvasRef}
+                style={{ display: "block" }}
+              />
+            </Box>
+
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 48px)",
+                gridTemplateRows: "repeat(3, 48px)",
+                gap: 1,
+              }}
+            >
+              <Box />
+              <Button
+                variant="outlined"
+                onClick={() => onMove("up")}
+                sx={{ minWidth: 0 }}
+              >
+                <KeyboardArrowUpIcon />
+              </Button>
+              <Box />
+
+              <Button
+                variant="outlined"
+                onClick={() => onMove("left")}
+                sx={{ minWidth: 0 }}
+              >
+                <KeyboardArrowLeftIcon />
+              </Button>
+              <Box />
+              <Button
+                variant="outlined"
+                onClick={() => onMove("right")}
+                sx={{ minWidth: 0 }}
+              >
+                <KeyboardArrowRightIcon />
+              </Button>
+
+              <Box />
+              <Button
+                variant="outlined"
+                onClick={() => onMove("down")}
+                sx={{ minWidth: 0 }}
+              >
+                <KeyboardArrowDownIcon />
+              </Button>
+              <Box />
+            </Box>
+
+            <Typography variant="caption" color="text.secondary">
+              矢印キーでも操作できます
+            </Typography>
+
+            <Stack direction="row" spacing={1}>
+              <Button variant="text" onClick={onBackToCreator}>
+                迷路作成ページへ戻る
+              </Button>
+              <Button variant="outlined" onClick={onPlayAgain}>
+                もう一度遊ぶ
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      </Stack>
+    </Container>
+  );
+};
+
+export default MazePlayPage;

--- a/frontend/src/maze-creator/wasm/src/lib.rs
+++ b/frontend/src/maze-creator/wasm/src/lib.rs
@@ -58,3 +58,26 @@ pub fn draw_maze(
     };
     ctx.stroke();
 }
+
+// ランダム迷路を生成して描画し、通路のビットマスク(セルごとにUP/RIGHT/DOWN/LEFTが開いているか)を返す。
+// このビットマスクをJS側で保持しておくことで、生成した迷路そのものをプレイ画面に引き継げる。
+#[wasm_bindgen]
+pub fn create_random_maze(canvas_id: String, row: usize, col: usize, space: f64) -> Vec<u8> {
+    let walls = maze::wall_grid::generate_walls(row, col);
+
+    if !random_maze::validate(row, col, space) {
+        return walls;
+    }
+
+    let ctx = dom::fetch_2d_context(&canvas_id);
+    let width = space * col as f64;
+    let height = space * row as f64;
+
+    ctx.clear_rect(0.0, 0.0, width, height);
+    ctx.begin_path();
+    ctx.rect(0.0, 0.0, width, height);
+    maze::wall_grid::draw_walls(&ctx, &walls, row, col, space);
+    ctx.stroke();
+
+    walls
+}

--- a/frontend/src/maze-creator/wasm/src/maze/maze_game.rs
+++ b/frontend/src/maze-creator/wasm/src/maze/maze_game.rs
@@ -1,0 +1,136 @@
+use wasm_bindgen::prelude::*;
+use web_sys::CanvasRenderingContext2d;
+
+use crate::dom;
+
+use super::wall_grid::{self, DOWN, LEFT, RIGHT, UP};
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+#[wasm_bindgen]
+pub struct MazeGame {
+    canvas_id: String,
+    walls: Vec<u8>,
+    rows: usize,
+    cols: usize,
+    space: f64,
+    player_row: usize,
+    player_col: usize,
+    goal_row: usize,
+    goal_col: usize,
+}
+
+#[wasm_bindgen]
+impl MazeGame {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        canvas_id: String,
+        walls: Vec<u8>,
+        rows: usize,
+        cols: usize,
+        space: f64,
+    ) -> MazeGame {
+        let game = MazeGame {
+            canvas_id,
+            walls,
+            rows,
+            cols,
+            space,
+            player_row: 0,
+            player_col: 0,
+            goal_row: rows.saturating_sub(1),
+            goal_col: cols.saturating_sub(1),
+        };
+        game.render();
+        game
+    }
+
+    // 移動できた場合はtrueを返し再描画する。壁に阻まれた場合はfalseを返し何もしない。
+    pub fn try_move(&mut self, direction: Direction) -> bool {
+        if self.rows == 0 || self.cols == 0 {
+            return false;
+        }
+
+        let idx = self.player_row * self.cols + self.player_col;
+        let cell = self.walls[idx];
+        let (bit, row_delta, col_delta): (u8, i64, i64) = match direction {
+            Direction::Up => (UP, -1, 0),
+            Direction::Right => (RIGHT, 0, 1),
+            Direction::Down => (DOWN, 1, 0),
+            Direction::Left => (LEFT, 0, -1),
+        };
+
+        if cell & bit == 0 {
+            return false;
+        }
+
+        let new_row = self.player_row as i64 + row_delta;
+        let new_col = self.player_col as i64 + col_delta;
+        if new_row < 0
+            || new_col < 0
+            || new_row as usize >= self.rows
+            || new_col as usize >= self.cols
+        {
+            return false;
+        }
+
+        self.player_row = new_row as usize;
+        self.player_col = new_col as usize;
+        self.render();
+        true
+    }
+
+    pub fn is_cleared(&self) -> bool {
+        self.player_row == self.goal_row && self.player_col == self.goal_col
+    }
+
+    pub fn player_row(&self) -> usize {
+        self.player_row
+    }
+
+    pub fn player_col(&self) -> usize {
+        self.player_col
+    }
+
+    fn render(&self) {
+        let ctx = dom::fetch_2d_context(&self.canvas_id);
+        let width = self.space * self.cols as f64;
+        let height = self.space * self.rows as f64;
+
+        ctx.clear_rect(0.0, 0.0, width, height);
+
+        ctx.begin_path();
+        ctx.rect(0.0, 0.0, width, height);
+        wall_grid::draw_walls(&ctx, &self.walls, self.rows, self.cols, self.space);
+        ctx.stroke();
+
+        draw_marker(&ctx, self.goal_row, self.goal_col, self.space, "#e53935");
+        draw_marker(
+            &ctx,
+            self.player_row,
+            self.player_col,
+            self.space,
+            "#1e88e5",
+        );
+    }
+}
+
+fn draw_marker(ctx: &CanvasRenderingContext2d, row: usize, col: usize, space: f64, color: &str) {
+    let center_x = col as f64 * space + space / 2.0;
+    let center_y = row as f64 * space + space / 2.0;
+    let radius = space * 0.3;
+
+    ctx.save();
+    ctx.set_fill_style_str(color);
+    ctx.begin_path();
+    let _ = ctx.arc(center_x, center_y, radius, 0.0, std::f64::consts::PI * 2.0);
+    ctx.fill();
+    ctx.restore();
+}

--- a/frontend/src/maze-creator/wasm/src/maze/mod.rs
+++ b/frontend/src/maze-creator/wasm/src/maze/mod.rs
@@ -1,3 +1,5 @@
 pub mod draw_shape;
+pub mod maze_game;
 pub mod random_maze;
 pub mod single_stroke_maze;
+pub mod wall_grid;

--- a/frontend/src/maze-creator/wasm/src/maze/wall_grid.rs
+++ b/frontend/src/maze-creator/wasm/src/maze/wall_grid.rs
@@ -1,0 +1,115 @@
+use web_sys::CanvasRenderingContext2d;
+
+use crate::algo::kruskal;
+
+pub const UP: u8 = 1 << 0;
+pub const RIGHT: u8 = 1 << 1;
+pub const DOWN: u8 = 1 << 2;
+pub const LEFT: u8 = 1 << 3;
+
+// 行(row) x 列(col)のグリッドについて、kruskal法で生成した最小全域木の
+// 使用した辺=通路として、セルごとに開いている方向をビットマスクで返す。
+// このビットマスクは draw_walls での描画とプレイ時の移動判定の両方で使う。
+pub fn generate_walls(row: usize, col: usize) -> Vec<u8> {
+    let mut walls = vec![0u8; row * col];
+    if row == 0 || col == 0 {
+        return walls;
+    }
+
+    let used_edges =
+        kruskal::extract_maze_edges_by_kruskal(col, row, 1, kruskal::KruskalResultEdge::Used);
+
+    for (a, b) in used_edges {
+        let idx_a = a.x * col + a.y;
+        let idx_b = b.x * col + b.y;
+        if a.x == b.x {
+            if a.y + 1 == b.y {
+                walls[idx_a] |= RIGHT;
+                walls[idx_b] |= LEFT;
+            } else if b.y + 1 == a.y {
+                walls[idx_b] |= RIGHT;
+                walls[idx_a] |= LEFT;
+            }
+        } else if a.y == b.y {
+            if a.x + 1 == b.x {
+                walls[idx_a] |= DOWN;
+                walls[idx_b] |= UP;
+            } else if b.x + 1 == a.x {
+                walls[idx_b] |= DOWN;
+                walls[idx_a] |= UP;
+            }
+        }
+    }
+
+    walls
+}
+
+// walls ビットマスクから内壁を描画する。外周は呼び出し側で rect を描く想定。
+// 各セルの右側・下側だけを見ることで、隣接セルとの二重描画を避ける。
+pub fn draw_walls(
+    ctx: &CanvasRenderingContext2d,
+    walls: &[u8],
+    row: usize,
+    col: usize,
+    space: f64,
+) {
+    for r in 0..row {
+        for c in 0..col {
+            let cell = walls[r * col + c];
+            if c + 1 < col && cell & RIGHT == 0 {
+                let x = (c + 1) as f64 * space;
+                ctx.move_to(x, r as f64 * space);
+                ctx.line_to(x, (r + 1) as f64 * space);
+            }
+            if r + 1 < row && cell & DOWN == 0 {
+                let y = (r + 1) as f64 * space;
+                ctx.move_to(c as f64 * space, y);
+                ctx.line_to((c + 1) as f64 * space, y);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_cell_has_at_least_one_open_direction() {
+        let row = 6;
+        let col = 5;
+        let walls = generate_walls(row, col);
+
+        assert_eq!(row * col, walls.len());
+        for cell in walls {
+            assert_ne!(0, cell, "spanning tree should connect every cell");
+        }
+    }
+
+    #[test]
+    fn open_directions_are_mutually_consistent() {
+        let row = 4;
+        let col = 4;
+        let walls = generate_walls(row, col);
+
+        for r in 0..row {
+            for c in 0..col {
+                let cell = walls[r * col + c];
+                if cell & RIGHT != 0 {
+                    assert!(c + 1 < col);
+                    assert_ne!(0, walls[r * col + c + 1] & LEFT);
+                }
+                if cell & DOWN != 0 {
+                    assert!(r + 1 < row);
+                    assert_ne!(0, walls[(r + 1) * col + c] & UP);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn zero_sized_grid_returns_empty() {
+        assert_eq!(0, generate_walls(0, 5).len());
+        assert_eq!(0, generate_walls(5, 0).len());
+    }
+}


### PR DESCRIPTION
## Summary
- maze-creatorの既存Rust/wasmクレートに `wall_grid`（Kruskal法で生成した通路をセルごとのビットマスクとして返す）と `MazeGame`（プレイヤー/ゴール位置、移動判定、キャンバス描画を持つwasm-bindgen構造体）を追加
- `create_random_maze` を新設し、プレビュー描画と同じ壁データを返すことで、作成した迷路をそのままプレイ画面に引き継げるようにした
- MazeCreatorPageに「この迷路で遊ぶ」ボタンを追加（一筆書きモードでは無効化）。押すとCSR遷移で `/maze/play` へ移動し、上下左右ボタン（矢印キーにも対応）で迷路を操作できる
- container/presentationパターンに沿って `presentation/page/play/MazePlayPage` と `container/page/play` を新規作成

## Test plan
- [x] `cargo fmt -- --check` / `cargo test`（wallビットマスクの整合性テストを含む）
- [x] `tsc -b` / `npm run lint`
- [x] `wasm-pack build --target bundler` でpkg生成を確認
- [x] ブラウザでランダム迷路を生成→「この迷路で遊ぶ」→ボタン/矢印キーでの移動、壁での衝突判定、BFSで解いてゴール到達時に「クリア！」が出ることを確認
- [x] 一筆書きモードでボタンが無効化されること、`/maze/play` に直接アクセスした場合のフォールバック表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)