### PR TITLE
迷路プレビューに2Dタイル表示トグルを追加

### DIFF
--- a/frontend/src/maze-creator/container/MazeCreatorPage.tsx
+++ b/frontend/src/maze-creator/container/MazeCreatorPage.tsx
@@ -22,8 +22,15 @@ import Grid from "@mui/material/Grid";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
+import GridViewIcon from "@mui/icons-material/GridView";
 
-import { create_random_maze, draw_maze, MazeType } from "../wasm/pkg/wasm.js";
+import {
+  create_random_maze,
+  draw_maze,
+  draw_random_maze,
+  draw_random_maze_tiles,
+  MazeType,
+} from "../wasm/pkg/wasm.js";
 import type { MazePlayLocationState } from "../presentation/page/play/MazePlayPage";
 
 type GridParams = {
@@ -34,6 +41,9 @@ type GridParams = {
 
 const DEFAULT_PARAMS: GridParams = { cellSize: 20, cols: 15, rows: 10 };
 type Mode = "random" | "single";
+type WallStyle = "1d" | "2d";
+
+const tileSizeFor = (cellSize: number) => Math.max(1, Math.floor(cellSize / 2));
 
 function MazeCreatorPage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -45,6 +55,7 @@ function MazeCreatorPage() {
   const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
   const [playableMaze, setPlayableMaze] =
     useState<MazePlayLocationState | null>(null);
+  const [wallStyle, setWallStyle] = useState<WallStyle>("1d");
 
   const { widthPx, heightPx } = useMemo(
     () => ({
@@ -84,43 +95,98 @@ function MazeCreatorPage() {
     return { errors, valid };
   }, [params, mode]);
 
+  const renderLines = (
+    rows: number,
+    cols: number,
+    cellSize: number,
+    walls: Uint8Array,
+  ) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = cols * cellSize;
+    canvas.height = rows * cellSize;
+    draw_random_maze("canvas", walls, rows, cols, cellSize);
+  };
+
+  const renderTiles = (
+    rows: number,
+    cols: number,
+    cellSize: number,
+    walls: Uint8Array,
+  ) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const tileSize = tileSizeFor(cellSize);
+    canvas.width = (2 * cols + 1) * tileSize;
+    canvas.height = (2 * rows + 1) * tileSize;
+    draw_random_maze_tiles("canvas", walls, rows, cols, tileSize);
+  };
+
   const ensureCanvasAndDraw = (
     { cellSize, cols, rows }: GridParams,
     m: Mode,
+    style: WallStyle,
   ) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const width = cellSize * cols;
-    const height = cellSize * rows;
-    canvas.width = width;
-    canvas.height = height;
     if (m === "single") {
+      canvas.width = cellSize * cols;
+      canvas.height = cellSize * rows;
       draw_maze(0, 0, rows, cols, cellSize, MazeType.SingleStroke);
       setPlayableMaze(null);
+      return;
+    }
+
+    canvas.width = cellSize * cols;
+    canvas.height = cellSize * rows;
+    const walls = create_random_maze("canvas", rows, cols, cellSize);
+    setPlayableMaze({ walls: Array.from(walls), rows, cols, cellSize });
+
+    if (style === "2d") {
+      renderTiles(rows, cols, cellSize, walls);
+    }
+  };
+
+  const onToggleWallStyle = () => {
+    if (!playableMaze) return;
+    const next: WallStyle = wallStyle === "1d" ? "2d" : "1d";
+    const { rows, cols, cellSize, walls } = playableMaze;
+    const wallsArray = Uint8Array.from(walls);
+
+    setWallStyle(next);
+    if (next === "2d") {
+      renderTiles(rows, cols, cellSize, wallsArray);
     } else {
-      const walls = create_random_maze("canvas", rows, cols, cellSize);
-      setPlayableMaze({ walls: Array.from(walls), rows, cols, cellSize });
+      renderLines(rows, cols, cellSize, wallsArray);
     }
   };
 
   useEffect(() => {
     if (!autoPreview || !validation.valid) return;
-    const t = setTimeout(() => ensureCanvasAndDraw(params, mode), 300);
+    const t = setTimeout(
+      () => ensureCanvasAndDraw(params, mode, wallStyle),
+      300,
+    );
     return () => clearTimeout(t);
+    // wallStyle is intentionally excluded: toggling it re-renders the
+    // existing maze in place (see onToggleWallStyle) and must not trigger
+    // a fresh create_random_maze regeneration here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoPreview, validation.valid, params, mode]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!validation.valid) return;
-    ensureCanvasAndDraw(params, mode);
+    ensureCanvasAndDraw(params, mode, wallStyle);
   };
 
   const onReset = () => {
     setParams(DEFAULT_PARAMS);
     setMode("random");
+    setWallStyle("1d");
     if (autoPreview) {
-      ensureCanvasAndDraw(DEFAULT_PARAMS, "random");
+      ensureCanvasAndDraw(DEFAULT_PARAMS, "random", "1d");
     }
   };
 
@@ -319,21 +385,33 @@ function MazeCreatorPage() {
                 justifyContent="space-between"
               >
                 <Typography variant="subtitle1">プレビュー</Typography>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  size="small"
-                  startIcon={<SportsEsportsIcon />}
-                  disabled={!playableMaze}
-                  onClick={onPlay}
-                >
-                  この迷路で遊ぶ
-                </Button>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    size="small"
+                    startIcon={<GridViewIcon />}
+                    disabled={!playableMaze}
+                    onClick={onToggleWallStyle}
+                  >
+                    {wallStyle === "1d" ? "2Dタイル表示に切替" : "1D表示に戻す"}
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    size="small"
+                    startIcon={<SportsEsportsIcon />}
+                    disabled={!playableMaze}
+                    onClick={onPlay}
+                  >
+                    この迷路で遊ぶ
+                  </Button>
+                </Stack>
               </Stack>
               <Typography variant="caption" color="text.secondary">
                 {widthPx} x {heightPx} px
                 {mode === "single" &&
-                  "（一筆書きモードはプレイに対応していません）"}
+                  "（一筆書きモードはプレイ・2Dタイル表示に対応していません）"}
               </Typography>
               <Box
                 sx={{

--- a/frontend/src/maze-creator/wasm/src/lib.rs
+++ b/frontend/src/maze-creator/wasm/src/lib.rs
@@ -59,14 +59,22 @@ pub fn draw_maze(
     ctx.stroke();
 }
 
-// ランダム迷路を生成して描画し、通路のビットマスク(セルごとにUP/RIGHT/DOWN/LEFTが開いているか)を返す。
-// このビットマスクをJS側で保持しておくことで、生成した迷路そのものをプレイ画面に引き継げる。
+// ランダム迷路を生成して1D(線)で描画し、通路のビットマスク(セルごとにUP/RIGHT/DOWN/LEFTが
+// 開いているか)を返す。このビットマスクをJS側で保持しておくことで、生成した迷路そのものを
+// プレイ画面や別の描画スタイル(2Dタイル表示など)に引き継げる。
 #[wasm_bindgen]
 pub fn create_random_maze(canvas_id: String, row: usize, col: usize, space: f64) -> Vec<u8> {
     let walls = maze::wall_grid::generate_walls(row, col);
+    draw_random_maze(canvas_id, walls.clone(), row, col, space);
+    walls
+}
 
+// 既に生成済みの壁ビットマスクを、1D(線)で再描画する。迷路を再生成せずに
+// 表示スタイルだけを切り替えたい場合に使う。
+#[wasm_bindgen]
+pub fn draw_random_maze(canvas_id: String, walls: Vec<u8>, row: usize, col: usize, space: f64) {
     if !random_maze::validate(row, col, space) {
-        return walls;
+        return;
     }
 
     let ctx = dom::fetch_2d_context(&canvas_id);
@@ -78,6 +86,22 @@ pub fn create_random_maze(canvas_id: String, row: usize, col: usize, space: f64)
     ctx.rect(0.0, 0.0, width, height);
     maze::wall_grid::draw_walls(&ctx, &walls, row, col, space);
     ctx.stroke();
+}
 
-    walls
+// 既に生成済みの壁ビットマスクを、幅を持った2Dタイルとして再描画する。
+// 壁も床も同じ大きさのタイルとして並べたタイルマップになる。
+#[wasm_bindgen]
+pub fn draw_random_maze_tiles(
+    canvas_id: String,
+    walls: Vec<u8>,
+    row: usize,
+    col: usize,
+    tile_size: f64,
+) {
+    if row == 0 || col == 0 || !tile_size.is_finite() || tile_size <= 0.0 {
+        return;
+    }
+
+    let ctx = dom::fetch_2d_context(&canvas_id);
+    maze::tile_grid::draw_tiles(&ctx, &walls, row, col, tile_size);
 }

--- a/frontend/src/maze-creator/wasm/src/maze/mod.rs
+++ b/frontend/src/maze-creator/wasm/src/maze/mod.rs
@@ -2,4 +2,5 @@ pub mod draw_shape;
 pub mod maze_game;
 pub mod random_maze;
 pub mod single_stroke_maze;
+pub mod tile_grid;
 pub mod wall_grid;

--- a/frontend/src/maze-creator/wasm/src/maze/tile_grid.rs
+++ b/frontend/src/maze-creator/wasm/src/maze/tile_grid.rs
@@ -1,0 +1,158 @@
+use web_sys::CanvasRenderingContext2d;
+
+use super::wall_grid::{DOWN, LEFT, RIGHT, UP};
+
+// 壁ビットマスクのグリッド(row x col)を、壁も床も同じ大きさのタイルとして
+// 表現した (2*row+1) x (2*col+1) のタイルグリッドに変換する。
+// 偶数インデックスの行・列は壁(または柱)、奇数インデックスは元のセル(床)を表す。
+pub fn tile_dimensions(row: usize, col: usize) -> (usize, usize) {
+    (2 * row + 1, 2 * col + 1)
+}
+
+pub fn build_tile_grid(walls: &[u8], row: usize, col: usize) -> Vec<bool> {
+    let (tile_rows, tile_cols) = tile_dimensions(row, col);
+    let mut tiles = vec![true; tile_rows * tile_cols];
+
+    for r in 0..row {
+        for c in 0..col {
+            let cell = walls[r * col + c];
+            let tr = 2 * r + 1;
+            let tc = 2 * c + 1;
+
+            tiles[tr * tile_cols + tc] = false;
+
+            if cell & RIGHT != 0 {
+                tiles[tr * tile_cols + (tc + 1)] = false;
+            }
+            if cell & DOWN != 0 {
+                tiles[(tr + 1) * tile_cols + tc] = false;
+            }
+            if cell & LEFT != 0 {
+                tiles[tr * tile_cols + (tc - 1)] = false;
+            }
+            if cell & UP != 0 {
+                tiles[(tr - 1) * tile_cols + tc] = false;
+            }
+        }
+    }
+
+    tiles
+}
+
+pub fn draw_tiles(
+    ctx: &CanvasRenderingContext2d,
+    walls: &[u8],
+    row: usize,
+    col: usize,
+    tile_size: f64,
+) {
+    let (tile_rows, tile_cols) = tile_dimensions(row, col);
+    let tiles = build_tile_grid(walls, row, col);
+
+    let width = tile_cols as f64 * tile_size;
+    let height = tile_rows as f64 * tile_size;
+    ctx.clear_rect(0.0, 0.0, width, height);
+
+    for r in 0..tile_rows {
+        for c in 0..tile_cols {
+            let x = c as f64 * tile_size;
+            let y = r as f64 * tile_size;
+            if tiles[r * tile_cols + c] {
+                draw_wall_tile(ctx, x, y, tile_size);
+            } else {
+                draw_floor_tile(ctx, x, y, tile_size);
+            }
+        }
+    }
+}
+
+fn draw_floor_tile(ctx: &CanvasRenderingContext2d, x: f64, y: f64, size: f64) {
+    ctx.set_fill_style_str("#f2efe8");
+    ctx.fill_rect(x, y, size, size);
+    ctx.set_stroke_style_str("#dedad0");
+    ctx.set_line_width(1.0);
+    ctx.stroke_rect(x + 0.5, y + 0.5, size - 1.0, size - 1.0);
+}
+
+fn draw_wall_tile(ctx: &CanvasRenderingContext2d, x: f64, y: f64, size: f64) {
+    ctx.set_fill_style_str("#5d4a3a");
+    ctx.fill_rect(x, y, size, size);
+
+    let inset = (size * 0.15).max(1.0);
+    if size - inset * 2.0 > 0.0 {
+        ctx.set_fill_style_str("#7a624c");
+        ctx.fill_rect(x + inset, y + inset, size - inset * 2.0, size - inset * 2.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::maze::wall_grid::generate_walls;
+
+    #[test]
+    fn tile_grid_has_expected_dimensions() {
+        let row = 4;
+        let col = 5;
+        let walls = generate_walls(row, col);
+        let tiles = build_tile_grid(&walls, row, col);
+
+        let (tile_rows, tile_cols) = tile_dimensions(row, col);
+        assert_eq!(2 * row + 1, tile_rows);
+        assert_eq!(2 * col + 1, tile_cols);
+        assert_eq!(tile_rows * tile_cols, tiles.len());
+    }
+
+    #[test]
+    fn cell_centers_are_always_floor() {
+        let row = 4;
+        let col = 5;
+        let walls = generate_walls(row, col);
+        let tiles = build_tile_grid(&walls, row, col);
+        let (_, tile_cols) = tile_dimensions(row, col);
+
+        for r in 0..row {
+            for c in 0..col {
+                let idx = (2 * r + 1) * tile_cols + (2 * c + 1);
+                assert!(!tiles[idx], "cell ({r},{c}) center should be floor");
+            }
+        }
+    }
+
+    #[test]
+    fn corners_are_always_wall() {
+        let row = 4;
+        let col = 5;
+        let walls = generate_walls(row, col);
+        let tiles = build_tile_grid(&walls, row, col);
+        let (tile_rows, tile_cols) = tile_dimensions(row, col);
+
+        for r in (0..tile_rows).step_by(2) {
+            for c in (0..tile_cols).step_by(2) {
+                assert!(tiles[r * tile_cols + c], "corner ({r},{c}) should be wall");
+            }
+        }
+    }
+
+    #[test]
+    fn open_passage_produces_floor_tile_between_cells() {
+        let row = 2;
+        let col = 2;
+        // 2x2の全域木は必ず3本の通路を持つので、少なくとも1つは通路タイルがあるはず。
+        let walls = generate_walls(row, col);
+        let tiles = build_tile_grid(&walls, row, col);
+        let (_, tile_cols) = tile_dimensions(row, col);
+
+        let has_any_open_wall_slot = (0..row).any(|r| {
+            (0..col).any(|c| {
+                let cell = walls[r * col + c];
+                let tr = 2 * r + 1;
+                let tc = 2 * c + 1;
+                (cell & RIGHT != 0 && !tiles[tr * tile_cols + (tc + 1)])
+                    || (cell & DOWN != 0 && !tiles[(tr + 1) * tile_cols + tc])
+            })
+        });
+
+        assert!(has_any_open_wall_slot);
+    }
+}


### PR DESCRIPTION
## Summary
- 壁ビットマスクを `(2*rows+1) x (2*cols+1)` のタイルグリッドに展開する `tile_grid.rs` を追加。壁も床も同じ大きさのタイルとして描画することで、線ではなく実際の幅を持った壁になる
- `create_random_maze` を「生成」と「描画」に分離し、`draw_random_maze`（1D線）/ `draw_random_maze_tiles`（2Dタイル）を新設。同じ壁データを再利用するだけで、迷路を再生成せずに表示スタイルだけ切り替えられる
- MazeCreatorPageに「2Dタイル表示に切替」ボタンを追加（一筆書きモードでは壁ビットマスクを持たないため無効化）

## Base branch
このPRは #101 (`feat/wasm-game`) の上に積んだ差分です。#101がマージされ次第、baseを `main` に付け替えます。

## Test plan
- [x] `cargo fmt -- --check` / `cargo test`（タイルグリッドの次元・床壁整合性テストを含む、全30件パス）
- [x] `tsc -b` / `npm run lint`
- [x] `wasm-pack build --target bundler` でpkg生成を確認
- [x] ブラウザで10x15・30x20の両方で1D⇄2D切り替えが同じ迷路を保ったまま動作することを確認
- [x] 2Dタイル表示中に「この迷路で遊ぶ」を押しても、プレイ画面に正しい迷路データが渡ることを確認
- [x] 一筆書きモードで両ボタンが無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)