### PR TITLE
fix: silence exhaustive-deps warning on mount-only preview render

### DIFF
--- a/frontend/src/presentation/widgets/MarkdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/presentation/widgets/MarkdownEditor/MarkdownEditor.tsx
@@ -64,7 +64,10 @@ const MarkdownEditor = (props: MarkdownEditorProps) => {
     const slugInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
+        // Render the initial preview once on mount; subsequent edits call
+        // updateMarkdown directly via handleChange/handleInsert instead.
         updateMarkdown(markdown);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const updateMarkdown = useCallback(async (text: string) => {


### PR DESCRIPTION
## Summary
- CI's frontend lint flagged `react-hooks/exhaustive-deps` on MarkdownEditor's mount-only preview effect (pre-existing code, surfaced because this file was touched in #102)
- The effect intentionally renders the initial preview once on mount; every subsequent edit already calls `updateMarkdown` directly via `handleChange`/`handleInsert`, so adding `markdown`/`updateMarkdown` to the deps array would just double-run it on every keystroke
- Documented the intent with a comment and scoped an `eslint-disable-next-line` to just this effect

## Test plan
- [x] `npm run lint` — warning gone, only pre-existing unrelated warnings in a generated file remain
- [x] `npx tsc -b` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)