### PR TITLE
fix: allow deleting the last character in the markdown editor

### DIFF
--- a/frontend/src/presentation/widgets/MarkdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/presentation/widgets/MarkdownEditor/MarkdownEditor.tsx
@@ -71,7 +71,6 @@ const MarkdownEditor = (props: MarkdownEditorProps) => {
     }, []);
 
     const updateMarkdown = useCallback(async (text: string) => {
-        if(text == '') return;
         setMarkdown(text);
         const rawHtml = await marked.parse(text);
         const sanitizedHtml = sanitizeHtml(rawHtml, {


### PR DESCRIPTION
## Summary
- Markdown エディタで内容が空文字列になる編集（最後の1文字を削除する、全選択して削除する等）をすると、見た目上その削除が反映されない不具合を修正
- 原因: `updateMarkdown()` に `if(text == '') return;` というガードがあり、空文字列になった際に `setMarkdown` が呼ばれず React state が更新されなかった。テキストエリアはこの state に紐づく controlled input で、シンタックスハイライト表示も同じ state を参照する `<pre>` オーバーレイなので、state が更新されないと視覚的に文字が消えたように見えない
- このガードは `f00959d`（マウント時に一度だけ空のプレビューを描画しないための対応）で追加されたものだが、ユーザーの編集操作にも誤って適用されていた。`marked.parse('')` / `sanitizeHtml('')` は空文字列でも安全なため、ガードごと削除

## Test plan
- [x] `npx eslint` で対象ファイルにエラーがないことを確認
- [x] Storybook (`MarkdownEditor--Default`) で1文字入力→Backspaceで削除し、プレースホルダーに戻ることを確認（修正前はこのケースで文字が消えなかった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)